### PR TITLE
Fix for error when running cookiecutter - main.py not parsed properly by cookiecutter

### DIFF
--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.src_package_name}}_fastapi/main.py
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.src_package_name}}_fastapi/main.py
@@ -11,9 +11,10 @@ LOGGER.info("Setting up logging configuration.")
 {{cookiecutter.src_package_name_short}}.general_utils.setup_logging(
     logging_config_path={{cookiecutter.src_package_name_short}}_fapi.config.SETTINGS.LOGGER_CONFIG_PATH)
 
+API_V1_STR = {{cookiecutter.src_package_name_short}}_fapi.config.SETTINGS.API_V1_STR
 APP = fastapi.FastAPI(
     title={{cookiecutter.src_package_name_short}}_fapi.config.SETTINGS.API_NAME,
-    openapi_url=f"{{{cookiecutter.src_package_name_short}}_fapi.config.SETTINGS.API_V1_STR}/openapi.json")
+    openapi_url=f"{API_V1_STR}/openapi.json")
 API_ROUTER = fastapi.APIRouter()
 API_ROUTER.include_router(
     {{cookiecutter.src_package_name_short}}_fapi.v1.routers.model.ROUTER, prefix="/model", tags=["model"])


### PR DESCRIPTION
Traceback:
```
...
  File "/opt/homebrew/Cellar/cookiecutter/1.7.3_1/libexec/lib/python3.10/site-packages/cookiecutter/generate.py", l
ine 169, in generate_file
    tmpl = env.get_template(infile_fwd_slashes)
  File "/opt/homebrew/Cellar/cookiecutter/1.7.3_1/libexec/lib/python3.10/site-packages/jinja2/environment.py", line
 996, in get_template
    return self._load_template(name, globals)
  File "/opt/homebrew/Cellar/cookiecutter/1.7.3_1/libexec/lib/python3.10/site-packages/jinja2/environment.py", line
 957, in _load_template
    template = self.loader.load(self, name, self.make_globals(globals))
  File "/opt/homebrew/Cellar/cookiecutter/1.7.3_1/libexec/lib/python3.10/site-packages/jinja2/loaders.py", line 137
, in load
    code = environment.compile(source, name, filename)
  File "/opt/homebrew/Cellar/cookiecutter/1.7.3_1/libexec/lib/python3.10/site-packages/jinja2/environment.py", line
 756, in compile
    self.handle_exception(source=source_hint)
  File "/opt/homebrew/Cellar/cookiecutter/1.7.3_1/libexec/lib/python3.10/site-packages/jinja2/environment.py", line
 924, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "./src/{{cookiecutter.src_package_name}}_fastapi/main.py", line 16, in <module>
jinja2.exceptions.TemplateSyntaxError: expected token ':', got '}'
  File "./src/{{cookiecutter.src_package_name}}_fastapi/main.py", line 16
    openapi_url=f"{{{cookiecutter.src_package_name_short}}_fapi.config.SETTINGS.API_V1_STR}/openapi.json")
```